### PR TITLE
remove Post Formats suppor by default

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -62,14 +62,6 @@ function _s_setup() {
 		'search-form', 'comment-form', 'comment-list', 'gallery', 'caption',
 	) );
 
-	/*
-	 * Enable support for Post Formats.
-	 * See http://codex.wordpress.org/Post_Formats
-	 */
-	add_theme_support( 'post-formats', array(
-		'aside', 'image', 'video', 'quote', 'link',
-	) );
-
 	// Set up the WordPress core custom background feature.
 	add_theme_support( 'custom-background', apply_filters( '_s_custom_background_args', array(
 		'default-color' => 'ffffff',


### PR DESCRIPTION
IMO it is rare that we typically need Post Formats by default on a project. Might want to discuss the PR in weekly Designer meeting to verify?

It is easy enough to reenable in a project if/when needed.