### PR TITLE
Added omega reset

### DIFF
--- a/sass/utilities/mixins/_omega-reset.scss
+++ b/sass/utilities/mixins/_omega-reset.scss
@@ -1,0 +1,9 @@
+// ------------------------------------------------------------
+// Omega Reset
+// Courtesy of Josh Fry: http://www.joshfry.me/blog/2013/05/13/omega-reset-for-bourbon-neat
+// ------------------------------------------------------------
+
+@mixin omega-reset($nth) {
+  &:nth-child(#{$nth}) { margin-right: flex-gutter(); }
+  &:nth-child(#{$nth}+1) { clear: none }
+}

--- a/sass/utilities/mixins/index.scss
+++ b/sass/utilities/mixins/index.scss
@@ -2,4 +2,5 @@
 @import "icon-font-awesome";
 @import "margin-auto";
 @import "media-queries";
+@import "omega-reset";
 @import "word-break";


### PR DESCRIPTION
This will add the ability to reset the automatic row number (omega). Comes in handy when you have nested columns for jQuery UI tabs.

Example:
.tabs {
     @include span-columns(6);
     @include omega(2n);
           .sub-tabs {
                @include omega-reset(2n);
                @include span-columns(4);
                @include omega(3n);
  }
}