### PR TITLE
improve out-of-box usability of base layout to jumpstart new projects

### DIFF
--- a/404.php
+++ b/404.php
@@ -7,7 +7,8 @@
 
 get_header(); ?>
 
-	<div class="primary content-area">
+	<div class="wrap content-area">
+		
 		<main id="main" class="site-main" role="main">
 
 			<section class="error-404 not-found">
@@ -51,6 +52,7 @@ get_header(); ?>
 			</section><!-- .error-404 -->
 
 		</main><!-- #main -->
-	</div><!-- .primary -->
+		
+	</div><!-- .wrap -->
 
 <?php get_footer(); ?>

--- a/archive.php
+++ b/archive.php
@@ -9,41 +9,46 @@
 
 get_header(); ?>
 
-	<div class="primary content-area">
-		<main id="main" class="site-main" role="main">
+	<div class="wrap">
+		
+		<div class="primary content-area">
+			<main id="main" class="site-main" role="main">
+	
+			<?php if ( have_posts() ) : ?>
+	
+				<header class="page-header">
+					<?php
+						the_archive_title( '<h1 class="page-title">', '</h1>' );
+						the_archive_description( '<div class="taxonomy-description">', '</div>' );
+					?>
+				</header><!-- .page-header -->
+	
+				<?php /* Start the Loop */ ?>
+				<?php while ( have_posts() ) : the_post(); ?>
+	
+					<?php
+						/* Include the Post-Format-specific template for the content.
+						 * If you want to override this in a child theme, then include a file
+						 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
+						 */
+						get_template_part( 'content', get_post_format() );
+					?>
+	
+				<?php endwhile; ?>
+	
+				<?php the_posts_navigation(); ?>
+	
+			<?php else : ?>
+	
+				<?php get_template_part( 'content', 'none' ); ?>
+	
+			<?php endif; ?>
+	
+			</main><!-- #main -->
+		</div><!-- .primary -->
+	
+		<?php get_sidebar(); ?>
 
-		<?php if ( have_posts() ) : ?>
-
-			<header class="page-header">
-				<?php
-					the_archive_title( '<h1 class="page-title">', '</h1>' );
-					the_archive_description( '<div class="taxonomy-description">', '</div>' );
-				?>
-			</header><!-- .page-header -->
-
-			<?php /* Start the Loop */ ?>
-			<?php while ( have_posts() ) : the_post(); ?>
-
-				<?php
-					/* Include the Post-Format-specific template for the content.
-					 * If you want to override this in a child theme, then include a file
-					 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
-					 */
-					get_template_part( 'content', get_post_format() );
-				?>
-
-			<?php endwhile; ?>
-
-			<?php the_posts_navigation(); ?>
-
-		<?php else : ?>
-
-			<?php get_template_part( 'content', 'none' ); ?>
-
-		<?php endif; ?>
-
-		</main><!-- #main -->
-	</div><!-- .primary -->
-
-<?php get_sidebar(); ?>
+	</div><!-- .wrap -->
+	
 <?php get_footer(); ?>

--- a/index.php
+++ b/index.php
@@ -13,34 +13,39 @@
 
 get_header(); ?>
 
-	<div class="primary content-area">
-		<main id="main" class="site-main" role="main">
-
-		<?php if ( have_posts() ) : ?>
-
-			<?php /* Start the Loop */ ?>
-			<?php while ( have_posts() ) : the_post(); ?>
-
-				<?php
-					/* Include the Post-Format-specific template for the content.
-					 * If you want to override this in a child theme, then include a file
-					 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
-					 */
-					get_template_part( 'content', get_post_format() );
-				?>
-
-			<?php endwhile; ?>
-
-			<?php the_posts_navigation(); ?>
-
-		<?php else : ?>
-
-			<?php get_template_part( 'content', 'none' ); ?>
-
-		<?php endif; ?>
-
-		</main><!-- #main -->
-	</div><!-- .primary -->
-
-<?php get_sidebar(); ?>
+	<div class="wrap">
+		
+		<div class="primary content-area">
+			<main id="main" class="site-main" role="main">
+	
+			<?php if ( have_posts() ) : ?>
+	
+				<?php /* Start the Loop */ ?>
+				<?php while ( have_posts() ) : the_post(); ?>
+	
+					<?php
+						/* Include the Post-Format-specific template for the content.
+						 * If you want to override this in a child theme, then include a file
+						 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
+						 */
+						get_template_part( 'content', get_post_format() );
+					?>
+	
+				<?php endwhile; ?>
+	
+				<?php the_posts_navigation(); ?>
+	
+			<?php else : ?>
+	
+				<?php get_template_part( 'content', 'none' ); ?>
+	
+			<?php endif; ?>
+	
+			</main><!-- #main -->
+		</div><!-- .primary -->
+	
+		<?php get_sidebar(); ?>
+	
+	</div><!-- .wrap -->
+	
 <?php get_footer(); ?>

--- a/page.php
+++ b/page.php
@@ -12,24 +12,29 @@
 
 get_header(); ?>
 
-	<div class="primary content-area">
-		<main id="main" class="site-main" role="main">
-
-			<?php while ( have_posts() ) : the_post(); ?>
-
-				<?php get_template_part( 'content', 'page' ); ?>
-
-				<?php
-					// If comments are open or we have at least one comment, load up the comment template
-					if ( comments_open() || get_comments_number() ) :
-						comments_template();
-					endif;
-				?>
-
-			<?php endwhile; // end of the loop. ?>
-
-		</main><!-- #main -->
-	</div><!-- .primary -->
-
-<?php get_sidebar(); ?>
+	<div class="wrap">
+		
+		<div class="primary content-area">
+			<main id="main" class="site-main" role="main">
+	
+				<?php while ( have_posts() ) : the_post(); ?>
+	
+					<?php get_template_part( 'content', 'page' ); ?>
+	
+					<?php
+						// If comments are open or we have at least one comment, load up the comment template
+						if ( comments_open() || get_comments_number() ) :
+							comments_template();
+						endif;
+					?>
+	
+				<?php endwhile; // end of the loop. ?>
+	
+			</main><!-- #main -->
+		</div><!-- .primary -->
+	
+		<?php get_sidebar(); ?>
+	
+	</div><!-- .wrap -->
+	
 <?php get_footer(); ?>

--- a/sass/structure/_layout.scss
+++ b/sass/structure/_layout.scss
@@ -4,8 +4,18 @@
 
 // Structure
 
-.site {
+.wrap {
 	@include outer-container;
+	padding: 0 2*$gutter;
+	
+	@include wider-than(desktop) {
+		padding: 0;
+	}
+}
+
+.site-header,
+.site-footer {
+	padding: 0 2*$gutter;
 }
 
 .site-content {

--- a/search.php
+++ b/search.php
@@ -7,39 +7,44 @@
 
 get_header(); ?>
 
-	<section class="primary content-area">
-		<main id="main" class="site-main" role="main">
-
-		<?php if ( have_posts() ) : ?>
-
-			<header class="page-header">
-				<h1 class="page-title"><?php printf( esc_html__( 'Search Results for: %s', '_s' ), '<span>' . get_search_query() . '</span>' ); ?></h1>
-			</header><!-- .page-header -->
-
-			<?php /* Start the Loop */ ?>
-			<?php while ( have_posts() ) : the_post(); ?>
-
-				<?php
-				/**
-				 * Run the loop for the search to output the results.
-				 * If you want to overload this in a child theme then include a file
-				 * called content-search.php and that will be used instead.
-				 */
-				get_template_part( 'content', 'search' );
-				?>
-
-			<?php endwhile; ?>
-
-			<?php the_posts_navigation(); ?>
-
-		<?php else : ?>
-
-			<?php get_template_part( 'content', 'none' ); ?>
-
-		<?php endif; ?>
-
-		</main><!-- #main -->
-	</section><!-- .primary -->
-
-<?php get_sidebar(); ?>
+	<div class="wrap">
+		
+		<section class="primary content-area">
+			<main id="main" class="site-main" role="main">
+	
+			<?php if ( have_posts() ) : ?>
+	
+				<header class="page-header">
+					<h1 class="page-title"><?php printf( esc_html__( 'Search Results for: %s', '_s' ), '<span>' . get_search_query() . '</span>' ); ?></h1>
+				</header><!-- .page-header -->
+	
+				<?php /* Start the Loop */ ?>
+				<?php while ( have_posts() ) : the_post(); ?>
+	
+					<?php
+					/**
+					 * Run the loop for the search to output the results.
+					 * If you want to overload this in a child theme then include a file
+					 * called content-search.php and that will be used instead.
+					 */
+					get_template_part( 'content', 'search' );
+					?>
+	
+				<?php endwhile; ?>
+	
+				<?php the_posts_navigation(); ?>
+	
+			<?php else : ?>
+	
+				<?php get_template_part( 'content', 'none' ); ?>
+	
+			<?php endif; ?>
+	
+			</main><!-- #main -->
+		</section><!-- .primary -->
+	
+		<?php get_sidebar(); ?>
+	
+	</div><!-- .wrap -->
+	
 <?php get_footer(); ?>

--- a/single.php
+++ b/single.php
@@ -7,26 +7,31 @@
 
 get_header(); ?>
 
-	<div class="primary content-area">
-		<main id="main" class="site-main" role="main">
-
-		<?php while ( have_posts() ) : the_post(); ?>
-
-			<?php get_template_part( 'content', 'single' ); ?>
-
-			<?php the_post_navigation(); ?>
-
-			<?php
-				// If comments are open or we have at least one comment, load up the comment template
-				if ( comments_open() || get_comments_number() ) :
-					comments_template();
-				endif;
-			?>
-
-		<?php endwhile; // end of the loop. ?>
-
-		</main><!-- #main -->
-	</div><!-- .primary -->
-
-<?php get_sidebar(); ?>
+	<div class="wrap">
+		
+		<div class="primary content-area">
+			<main id="main" class="site-main" role="main">
+	
+			<?php while ( have_posts() ) : the_post(); ?>
+	
+				<?php get_template_part( 'content', 'single' ); ?>
+	
+				<?php the_post_navigation(); ?>
+	
+				<?php
+					// If comments are open or we have at least one comment, load up the comment template
+					if ( comments_open() || get_comments_number() ) :
+						comments_template();
+					endif;
+				?>
+	
+			<?php endwhile; // end of the loop. ?>
+	
+			</main><!-- #main -->
+		</div><!-- .primary -->
+	
+		<?php get_sidebar(); ?>
+		
+	</div><!-- .wrap -->
+	
 <?php get_footer(); ?>


### PR DESCRIPTION
Who uses .site out of the box? Centering the whole .site with same @include outer-container isn't all that useful. It seems like we tend to center main content, and header and footer have different widths. I always end up switching to .wrap and getting a basic layout going with this reusable class to center grid items.

This is not really a huge change, but just something to make jumpstarting a typical project a little quicker.

Also, set some simple left/right padding for mobile-first rails (using Neat's grid-settings.scss $gutter) on major layout areas, like header and footer. 