### PR TITLE
Menu pattern styling

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -23,7 +23,7 @@
 				wp_nav_menu( array(
 					'theme_location' => 'social',
 					'container'      => false,
-					'menu_class'     => 'menu-social',
+					'menu_class'     => 'menu-social menu menu-horizontal',
 					'link_before'    => '<span class="screen-reader-text">',
 					'link_after'     => '</span>'
 					)

--- a/header.php
+++ b/header.php
@@ -32,7 +32,7 @@
 
 		<nav id="site-navigation" class="main-navigation" role="navigation">
 			<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false"><?php _e( 'Primary Menu', '_s' ); ?></button>
-			<?php wp_nav_menu( array( 'theme_location' => 'primary', 'menu_id' => 'primary-menu' ) ); ?>
+			<?php wp_nav_menu( array( 'theme_location' => 'primary', 'menu_id' => 'primary-menu', 'menu_class' => 'menu dropdown' ) ); ?>
 		</nav><!-- #site-navigation -->
 	</header><!-- #masthead -->
 

--- a/header.php
+++ b/header.php
@@ -32,7 +32,13 @@
 
 		<nav id="site-navigation" class="main-navigation" role="navigation">
 			<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false"><?php _e( 'Primary Menu', '_s' ); ?></button>
-			<?php wp_nav_menu( array( 'theme_location' => 'primary', 'menu_id' => 'primary-menu', 'menu_class' => 'menu dropdown' ) ); ?>
+			<?php
+				wp_nav_menu( array( 
+					'theme_location' => 'primary', 
+					'menu_id'        => 'primary-menu', 
+					'menu_class'     => 'menu dropdown' 
+				) ); 
+			?>
 		</nav><!-- #site-navigation -->
 	</header><!-- #masthead -->
 

--- a/sass/modules/_navigation.scss
+++ b/sass/modules/_navigation.scss
@@ -21,32 +21,40 @@ a {
 // Default menu (active after a fresh WordPress install)
 
 .menu {
+	@include margin-padding-reset;
+	
+	list-style: none;
 
-	ul {
-
-		li {
-			margin: 0 rem(10) 0 0;
-		}
-
+	li {
+		margin: 0 rem(10) 0 0;
 	}
-
-}
-
-// Main navigation (after creating a menu in the dashboard)
-
-.main-navigation {
-	@include size(100% auto);
-
-	clear: both;
-	display: block;
-	float: left;
-
-	// Menu area
+	
 	ul {
-		display: none;
+		@include margin-padding-reset;
+		
 		list-style: none;
-		margin: 0;
-		padding-left: 0;
+	}
+	
+	&.menu-horizontal {
+		
+		li {
+			display: inline-block;
+		}
+	}
+	
+	&.menu-vertical {
+		
+		li {
+			margin: 0;
+		}
+		
+		a {
+			padding: rem(10);
+			border-bottom: 1px solid $color-background-hr;
+		}
+	}
+	
+	&.dropdown {
 
 		// Sub-menu
 		ul {
@@ -56,7 +64,7 @@ a {
 			position: absolute;
 			top: em(24px);
 			z-index: 99999;
-
+			
 			// Sub-sub menu
 			ul {
 				left: -999em;
@@ -71,6 +79,11 @@ a {
 					left: 100%;
 				}
 			}
+			
+			// Sub-menu links
+			a {
+				@include size(200px auto);
+			}
 
 			:hover > a,
 			.focus > a {
@@ -80,38 +93,47 @@ a {
 			a.focus {
 			}
 		}
-
-		// Sub-menu links
-		a {
-			@include size(200px auto);
-		}
-
+		
 		// Display sub-menu on hover
 		li:hover > ul,
 		li.focus > ul {
 			left: auto;
 		}
-	}
-
-	// Menu items
-	li {
-		float: left;
-		position: relative;
-
-		&:hover > a,
-		&.focus > a {
+		
+		// Menu items
+		li {
+			float: left;
+			position: relative;
+	
+			&:hover > a,
+			&.focus > a {
+			}
 		}
 	}
-
+	
 	// Menu hyperlinks
 	a {
 		display: block;
 		text-decoration: none;
 	}
-
+	
 	// Current items
 	.current_page_item a,
 	.current-menu-item a {
+	}
+}
+
+// Main navigation (after creating a menu in the dashboard)
+.main-navigation {
+	@include size(100% auto);
+
+	clear: both;
+	display: block;
+	float: left;
+
+	// Menu area
+	ul {
+		display: none;
 	}
 }
 

--- a/sass/modules/_social-menu.scss
+++ b/sass/modules/_social-menu.scss
@@ -4,12 +4,8 @@
 
 .menu-social {
 
-	margin: 0;
-	padding: 0;
-
 	li {
 		display: inline-block;
-		list-style: none;
 		margin-right: rem(24);
 
 		&:last-child {

--- a/sass/utilities/mixins/_margin-padding-reset.scss
+++ b/sass/utilities/mixins/_margin-padding-reset.scss
@@ -1,0 +1,27 @@
+// ----------------------------------------------------------------------
+
+  // Margin & Padding Reset
+
+// ----------------------------------------------------------------------
+
+////
+/// @author Greg Rickaby
+/// @group wds
+////
+
+/// Resets margin and padding on any element
+///
+/// @example scss - Basic Usage Sass
+///    .foo {
+///			@include margin-padding-reset;
+///    }
+///
+/// @example scss - Basic Usage CSS Output
+///    .foo {
+///         margin: 0;
+///         padding: 0;
+///    }
+@mixin margin-padding-reset {
+	margin: 0;
+	padding: 0;
+}

--- a/sass/utilities/mixins/index.scss
+++ b/sass/utilities/mixins/index.scss
@@ -1,6 +1,7 @@
 @import "hyphens";
 @import "icon-font-awesome";
 @import "margin-auto";
+@import "margin-padding-reset";
 @import "media-queries";
 @import "omega-reset";
 @import "word-break";


### PR DESCRIPTION
use .menu for any <ol> or <ul> to get rid of list-style and margin/padding to start fresh. Also, additional presentation classes available: .menu-horizontal, .menu-vertical, .dropdown, which extend the original .menu.  Hopefully this will keep menu building consistent and give simple baseline for starting new project.

Would be good to discuss in next Designer call, and I'll put on agenda.